### PR TITLE
Changes default extensions and skins paths

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -35,10 +35,6 @@ if ( !is_readable( $canastaLocalSettingsFilePath ) ) {
 
 // Canasta default settings below
 
-# Use custom "user-" prefixed path for extensions and skins
-$wgExtensionDirectory = "$IP/user-extensions";
-$wgStyleDirectory = "$IP/user-skins";
-
 ## The URL base path to the directory containing the wiki;
 ## defaults for all runtime URL paths are based off of this.
 ## For more information on customizing the URLs
@@ -47,7 +43,13 @@ $wgStyleDirectory = "$IP/user-skins";
 $wgScriptPath = "/w";
 $wgScriptExtension = ".php";
 $wgArticlePath = '/wiki/$1';
-$wgStylePath = $wgScriptPath . '/canasta-skins';
+
+# Use custom "user-" prefixed path for extensions
+$wgExtensionDirectory = "$IP/user-extensions";
+$wgExtensionAssetsPath = $wgScriptPath . '/user-extensions';
+# ..and for skins
+$wgStyleDirectory = "$IP/user-skins";
+$wgStylePath = $wgScriptPath . '/user-skins';
 
 ## The URL path to static resources (images, scripts, etc.)
 $wgResourceBasePath = $wgScriptPath;

--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -35,6 +35,10 @@ if ( !is_readable( $canastaLocalSettingsFilePath ) ) {
 
 // Canasta default settings below
 
+# Use custom "user-" prefixed path for extensions and skins
+$wgExtensionDirectory = "$IP/user-extensions";
+$wgStyleDirectory = "$IP/user-skins";
+
 ## The URL base path to the directory containing the wiki;
 ## defaults for all runtime URL paths are based off of this.
 ## For more information on customizing the URLs
@@ -43,7 +47,7 @@ if ( !is_readable( $canastaLocalSettingsFilePath ) ) {
 $wgScriptPath = "/w";
 $wgScriptExtension = ".php";
 $wgArticlePath = '/wiki/$1';
-$wgStylePath = $wgScriptPath . '/skins';
+$wgStylePath = $wgScriptPath . '/canasta-skins';
 
 ## The URL path to static resources (images, scripts, etc.)
 $wgResourceBasePath = $wgScriptPath;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
       - MW_SITEMAP_SUBDIR
       - MW_SITEMAP_IDENTIFIER
     volumes:
-      - ./extensions:/var/www/mediawiki/w/extensions
-      - ./skins:/var/www/mediawiki/w/skins
+      - ./extensions:/var/www/mediawiki/w/user-extensions
+      - ./skins:/var/www/mediawiki/w/user-skins
       - ./config:/mediawiki/config
       - ./images:/mediawiki/images
       - sitemap:/mediawiki/sitemap


### PR DESCRIPTION
Modifies `$wgExtensionDirectory` , `$wgExtensionAssetsPath` , `$wgStyleDirectory` and `$wgStylePath` to use `user-` prefixed directories by default to make it look for skins and extensions in user mounted `user-skins` and `user-extensions` catalogue when `wfLoadExtension`  and `wfLoadSkin` is called