### PR TITLE
Change CanastaUtils include location

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -5,6 +5,8 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	exit;
 }
 
+require_once "$IP/CanastaUtils.php";
+
 $canastaLocalSettingsFilePath = getenv( 'MW_VOLUME' ) . '/config/LocalSettings.php';
 if ( defined( 'MW_CONFIG_CALLBACK' ) ) {
 	// Called from WebInstaller or similar entry point

--- a/_sources/canasta/LocalSettings.php
+++ b/_sources/canasta/LocalSettings.php
@@ -5,5 +5,4 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	exit;
 }
 
-require_once "$IP/CanastaUtils.php";
 require_once "$IP/CanastaDefaultSettings.php";


### PR DESCRIPTION
`CanastaUtils.php` should be included from `CanastaDefaultSettings.php` because some people may want to remove this file from their Canasta derivative image. Our requirement for people is to never edit `sources/canasta/LocalSettings.php` and only edit `sources/canasta/CanastaDefaultSettings.php` for official Canasta support.

Does this change break anything?