### PR TITLE
Adds `poppler-utils` as an `xpdf` replacement for `PdfHandler`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN set x; \
 	default-mysql-client=1.0.7 \
 	rsync=3.2.3-4+deb11u1 \
     lynx \
+    poppler-utils \
     && aptitude update \
     && aptitude install -y \
     php7.4 \


### PR DESCRIPTION
PdfHandler was not functioning due to `pdfinfo` and `pdftotext` tools missing. This patch installs `poppler-utils` as a replacement for `xpdf-utils` for Debian.