### PR TITLE
Upgrades SimpleBatchUpload from `1.0` to `1.8.x`

### DIFF
--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -9,7 +9,7 @@
 		"mediawiki/semantic-compound-queries": "2.1.0",
 		"mediawiki/semantic-extra-special-properties": "2.1.0",
 		"mediawiki/semantic-scribunto": "2.1.0",
-		"mediawiki/simple-batch-upload": "1.0",
+		"mediawiki/simple-batch-upload": "1.8.0",
 		"mediawiki/bootstrap-components": "4.0.1",
 		"mediawiki/sub-page-list": "1.6.1"
 	},

--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -9,7 +9,7 @@
 		"mediawiki/semantic-compound-queries": "2.1.0",
 		"mediawiki/semantic-extra-special-properties": "2.1.0",
 		"mediawiki/semantic-scribunto": "2.1.0",
-		"mediawiki/simple-batch-upload": "1.8.0",
+		"mediawiki/simple-batch-upload": "1.8.2",
 		"mediawiki/bootstrap-components": "4.0.1",
 		"mediawiki/sub-page-list": "1.6.1"
 	},


### PR DESCRIPTION
The patch bumps SimpleBatchUpload version to `1.8.x`, it was tested on WikiTeq-Canasta and worked well there