### PR TITLE
Upgrades GitHub action to comply with new changes for save-state [1]

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       -
         name: Run linter (hadolint)
         uses: vedmaka/hadolint-action@master
@@ -45,7 +45,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Generate tags
         id: generate
@@ -96,16 +96,18 @@ jobs:
 
           echo "Final image tag to be pushed:"
           echo $REGISTRY_TAGS
-          echo "::set-output name=REGISTRY_TAGS::$REGISTRY_TAGS"
+          echo "REGISTRY_TAGS=$REGISTRY_TAGS" >> $GITHUB_OUTPUT
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
       -
         name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -113,7 +115,7 @@ jobs:
             ${{ runner.os }}-buildx-
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -121,7 +123,7 @@ jobs:
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64, linux/arm64


### PR DESCRIPTION
* Upgrades `actions/checkout@v2` -> `actions/checkout@v3`
* Upgrades `docker/setup-buildx-action@v1` -> `docker/setup-buildx-action@v2`
* Upgrades `actions/cache@v2` -> `actions/cache@v3`
* Upgrades `docker/login-action@v1` -> `docker/login-action@v2`
* Upgrades `docker/build-push-action@v2` -> `docker/build-push-action@v3`
* Adds `install` flag to `docker/setup-buildx-action` to make use of buildx cache
* Replaces `::set-output` with an environment file

1. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

p.s. this change also speeds up cached image build time by x10 ⚡ 