### PR TITLE
Add header warning to some special pages if $wgSMTP not set

### DIFF
--- a/_sources/canasta/CanastaUtils.php
+++ b/_sources/canasta/CanastaUtils.php
@@ -51,4 +51,4 @@ $wgHooks['SiteNoticeAfter'][] = function ( &$siteNotice, Skin $skin ) {
 
 	$siteNotice .= '<div class="warningbox" style="font-size: larger;">Please note that mailing does not currently work on this wiki, because Canasta requires <a href="https://www.mediawiki.org/wiki/Manual:$wgSMTP">$wgSMTP</a> to be set in order to send emails.</div>';
 	return true;
-}
+};

--- a/_sources/canasta/CanastaUtils.php
+++ b/_sources/canasta/CanastaUtils.php
@@ -22,3 +22,30 @@ function cfLoadSkin( $skinName ) {
 	echo "The following skin was loaded with cfLoadSkin, but needs to be loaded with wfLoadSkin instead: $skinName";
 	die();
 }
+
+/**
+ * Not exactly a utility function, but - show a warning to users if $wgSMTP is not set.
+ */
+$wgHooks['SiteNoticeAfter'][] = 'showSMTPWarning';
+function showSMTPWarning( &$siteNotice, Skin $skin ) {
+	global $wgSMTP;
+
+	if ( $wgSMTP !== false ) {
+		return true;
+	}
+	$title = $skin->getTitle();
+	if ( !$title->isSpecialPage() ) {
+		return true;
+	}
+	$specialPage = MediaWiki\MediaWikiServices::getInstance()
+		->getSpecialPageFactory()
+		->getPage( $title->getText() );
+	$canonicalName = $specialPage->getName();
+	// Only display this warning for pages that could result in an email getting sent.
+	if ( !in_array( $canonicalName, [ 'Preferences', 'CreateAccount', 'Emailuser' ] ) ) {
+		return true;
+	}
+
+	$siteNotice .= '<div class="warningbox"><big>Please note that mailing does not currently work on this wiki, because Canasta requires <a href="https://www.mediawiki.org/wiki/Manual:$wgSMTP">$wgSMTP</a> to be set in order to send emails.</big></div>';
+	return true;
+}

--- a/_sources/canasta/CanastaUtils.php
+++ b/_sources/canasta/CanastaUtils.php
@@ -30,11 +30,11 @@ $wgHooks['SiteNoticeAfter'][] = function ( &$siteNotice, Skin $skin ) {
 	global $wgSMTP, $wgEnableEmail, $wgEnableUserEmail;
 
 	if ( !$wgEnableEmail || $wgSMTP ) {
-		return true;
+		return;
 	}
 	$title = $skin->getTitle();
 	if ( !$title->isSpecialPage() ) {
-		return true;
+		return;
 	}
 	$specialPage = MediaWiki\MediaWikiServices::getInstance()
 		->getSpecialPageFactory()
@@ -46,9 +46,9 @@ $wgHooks['SiteNoticeAfter'][] = function ( &$siteNotice, Skin $skin ) {
 		$specialPagesWithEmail[] = 'Emailuser';
 	}
 	if ( !in_array( $canonicalName, $specialPagesWithEmail ) ) {
-		return true;
+		return;
 	}
 
-	$siteNotice .= '<div class="warningbox" style="font-size: larger;">Please note that mailing does not currently work on this wiki, because Canasta requires <a href="https://www.mediawiki.org/wiki/Manual:$wgSMTP">$wgSMTP</a> to be set in order to send emails.</div>';
-	return true;
+	$warningText = 'Please note that mailing does not currently work on this wiki, because Canasta requires <a href="https://www.mediawiki.org/wiki/Manual:$wgSMTP">$wgSMTP</a> to be set in order to send emails.';
+	$siteNotice .= Html::warningBox( '<span style="font-size: larger;">' . $warningText . '</span>' );
 };

--- a/_sources/canasta/CanastaUtils.php
+++ b/_sources/canasta/CanastaUtils.php
@@ -26,11 +26,10 @@ function cfLoadSkin( $skinName ) {
 /**
  * Not exactly a utility function, but - show a warning to users if $wgSMTP is not set.
  */
-$wgHooks['SiteNoticeAfter'][] = 'showSMTPWarning';
-function showSMTPWarning( &$siteNotice, Skin $skin ) {{
+$wgHooks['SiteNoticeAfter'][] = function ( &$siteNotice, Skin $skin ) {
 	global $wgSMTP, $wgEnableEmail, $wgEnableUserEmail;
 
-	if ( $wgEnableEmail == false || $wgSMTP !== false ) {
+	if ( !$wgEnableEmail || $wgSMTP ) {
 		return true;
 	}
 	$title = $skin->getTitle();
@@ -50,6 +49,6 @@ function showSMTPWarning( &$siteNotice, Skin $skin ) {{
 		return true;
 	}
 
-	$siteNotice .= '<div class="warningbox"><big>Please note that mailing does not currently work on this wiki, because Canasta requires <a href="https://www.mediawiki.org/wiki/Manual:$wgSMTP">$wgSMTP</a> to be set in order to send emails.</big></div>';
+	$siteNotice .= '<div class="warningbox" style="font-size: larger;">Please note that mailing does not currently work on this wiki, because Canasta requires <a href="https://www.mediawiki.org/wiki/Manual:$wgSMTP">$wgSMTP</a> to be set in order to send emails.</div>';
 	return true;
 }

--- a/_sources/canasta/CanastaUtils.php
+++ b/_sources/canasta/CanastaUtils.php
@@ -27,10 +27,10 @@ function cfLoadSkin( $skinName ) {
  * Not exactly a utility function, but - show a warning to users if $wgSMTP is not set.
  */
 $wgHooks['SiteNoticeAfter'][] = 'showSMTPWarning';
-function showSMTPWarning( &$siteNotice, Skin $skin ) {
-	global $wgSMTP;
+function showSMTPWarning( &$siteNotice, Skin $skin ) {{
+	global $wgSMTP, $wgEnableEmail, $wgEnableUserEmail;
 
-	if ( $wgSMTP !== false ) {
+	if ( $wgEnableEmail == false || $wgSMTP !== false ) {
 		return true;
 	}
 	$title = $skin->getTitle();
@@ -42,7 +42,11 @@ function showSMTPWarning( &$siteNotice, Skin $skin ) {
 		->getPage( $title->getText() );
 	$canonicalName = $specialPage->getName();
 	// Only display this warning for pages that could result in an email getting sent.
-	if ( !in_array( $canonicalName, [ 'Preferences', 'CreateAccount', 'Emailuser' ] ) ) {
+	$specialPagesWithEmail = [ 'Preferences', 'CreateAccount' ];
+	if ( $wgEnableUserEmail ) {
+		$specialPagesWithEmail[] = 'Emailuser';
+	}
+	if ( !in_array( $canonicalName, $specialPagesWithEmail ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #145.

A new version of the now-abandoned #187.