### PR TITLE
 Add monitoring for extensions and skins modifications.

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,6 +24,9 @@ jobs:
   # Test the image Dockerfile syntax using https://github.com/replicatedhq/dockerfilelint
   test:
     runs-on: ubuntu-latest
+    permissions:
+        contents: read
+        packages: write
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN set x; \
 	&& aptitude -y upgrade \
 	&& aptitude install -y \
 	git \
+	inotify-tools \
 	apache2 \
 	software-properties-common \
 	gpg \

--- a/_sources/scripts/inotifywait.sh
+++ b/_sources/scripts/inotifywait.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -x
+
+userexts="$MW_HOME/user-extensions"
+extensions="$MW_HOME/extensions"
+canexts="$MW_HOME/canasta-extensions"
+
+userskins="$MW_HOME/user-skins"
+skins="$MW_HOME/skins"
+canskins="$MW_HOME/canasta-skins"
+
+#  - Detects activity changes inside user-extensions and user-skins.                           
+#  - Adds symlinks from the those folders to the appropriate correspondent folders, user-extensions to extensions and user-skins to skins. 				       
+#  - As a fallback, the moment the extension is removed or moved from user-extensions it will revert back by adding a symlink to the extension
+#    located in canasta-extensions.  
+
+inotifywait -m -e create,moved_to,delete,moved_from --format '%e:%f%0' -- "$userexts" | 
+	while IFS=: read -r event file; do 
+		case $event in 
+			CREATE,ISDIR|MOVED_TO,ISDIR) 
+				ln -rsft "$extensions" -- "$userexts"/"$file" ;; 
+			DELETE,ISDIR|MOVED_FROM,ISDIR) 
+				echo "event: ${event} file: ${file}"; 
+				ln -rsft "$extensions" -- "$canexts"/"$file" || rm -- "$file";
+		esac 
+	done
+
+inotifywait -m -e create,moved_to,delete,moved_from --format '%e:%f%0' -- "$userskins" | 
+	while IFS=: read -r event file; do 
+		case $event in 
+			CREATE,ISDIR|MOVED_TO,ISDIR) 
+				ln -rsft skins -- "$userskins"/"$file" ;; 
+			DELETE,ISDIR|MOVED_FROM,ISDIR) 
+				echo "event: ${event} file: ${file}"; 
+				ln -rsft skins -- "$canskins"/"$file" || rm -- "$file"; 
+		esac 
+	done

--- a/_sources/scripts/run-apache.sh
+++ b/_sources/scripts/run-apache.sh
@@ -226,7 +226,7 @@ echo "Starting services..."
 jobrunner &
 transcoder &
 sitemapgen &
-
+inotifywait &
 ############### Run Apache ###############
 # Make sure we're not confused by old, incompletely-shutdown httpd
 # context after restarting the container.  httpd won't start correctly

--- a/_sources/scripts/run-apache.sh
+++ b/_sources/scripts/run-apache.sh
@@ -202,6 +202,10 @@ check_mount_points () {
   fi
 }
 
+inotifywait() {
+	runuser -c /monitor-directories.sh -s /bin/bash "$WWW_USER"	
+}
+
 # Wait db
 waitdatabase
 


### PR DESCRIPTION
- Inotifywait detects activity changes in the folders user-extensions and user-skins.
- Adds symlinks from the those folders to the appropriate correspondent folders, user-extensions to extensions and user-skins to skins. As a fallback, if the administrator wants to go back to the default extension provided by canasta-extensions folder it will then revert back.
- Dockerfile had to be updated because inotifywait isn't installed by default, so inotify-tools package add to be added to be installed.
- All scripts are called from Run-apache.sh, so  a call to inotifywait.sh was  added to that script.

