### PR TITLE
chore: switch to github mirrors for cloning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ FROM base as source
 
 # MediaWiki core
 RUN set -x; \
-	git clone --depth 1 -b $MW_CORE_VERSION https://gerrit.wikimedia.org/r/mediawiki/core.git $MW_HOME \
+	git clone --depth 1 -b $MW_CORE_VERSION https://github.com/wikimedia/mediawiki $MW_HOME \
 	&& cd $MW_HOME \
 	&& git submodule update --init --recursive
 
@@ -94,7 +94,7 @@ RUN set -x; \
 RUN set -x; \
 	cd $MW_HOME/skins \
 	# CologneBlue
-	&& git clone -b $MW_VERSION --single-branch https://gerrit.wikimedia.org/r/mediawiki/skins/CologneBlue $MW_HOME/skins/CologneBlue \
+	&& git clone -b $MW_VERSION --single-branch https://github.com/wikimedia/mediawiki-skins-CologneBlue $MW_HOME/skins/CologneBlue \
 	&& cd $MW_HOME/skins/CologneBlue \
 	&& git checkout -q 4d588eb78d7e64e574f631c5897579537305437d \
 	# MinervaNeue
@@ -102,7 +102,7 @@ RUN set -x; \
 	#&& cd $MW_HOME/skins/MinervaNeue \
 	#&& git checkout -q e4741ff2c4375c2befee0d9f350aff6eb6e1a4da \
 	# Modern
-	&& git clone -b $MW_VERSION --single-branch https://gerrit.wikimedia.org/r/mediawiki/skins/Modern $MW_HOME/skins/Modern \
+	&& git clone -b $MW_VERSION --single-branch https://github.com/wikimedia/mediawiki-skins-Modern $MW_HOME/skins/Modern \
 	&& cd $MW_HOME/skins/Modern \
 	&& git checkout -q fb6c2831b5f150e9b82d98d661710695a2d0f8f2 \
 	# Pivot
@@ -110,7 +110,7 @@ RUN set -x; \
 	&& cd $MW_HOME/skins/pivot \
 	&& git checkout -q d79af7514347eb5272936243d4013118354c85c1 \
 	# Refreshed
-	&& git clone -b $MW_VERSION --single-branch https://gerrit.wikimedia.org/r/mediawiki/skins/Refreshed $MW_HOME/skins/Refreshed \
+	&& git clone -b $MW_VERSION --single-branch https://github.com/wikimedia/mediawiki-skins-Refreshed $MW_HOME/skins/Refreshed \
 	&& cd $MW_HOME/skins/Refreshed \
 	&& git checkout -q 86f33620f25335eb62289aa18d342ff3b980d8b8
 
@@ -127,123 +127,123 @@ RUN set -x; \
 RUN set -x; \
 	cd $MW_HOME/extensions \
 	# AdminLinks
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/AdminLinks $MW_HOME/extensions/AdminLinks \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-AdminLinks $MW_HOME/extensions/AdminLinks \
 	&& cd $MW_HOME/extensions/AdminLinks \
 	&& git checkout -q ad7805941ee29378484d1ef3595041f7d2c15913 \
 	# AdvancedSearch
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/AdvancedSearch $MW_HOME/extensions/AdvancedSearch \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-AdvancedSearch $MW_HOME/extensions/AdvancedSearch \
 	&& cd $MW_HOME/extensions/AdvancedSearch \
 	&& git checkout -q 1a44eafc93a17938333b74a37cb4deff2192e50a \
 	# AJAXPoll
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/AJAXPoll $MW_HOME/extensions/AJAXPoll \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-AJAXPoll $MW_HOME/extensions/AJAXPoll \
 	&& cd $MW_HOME/extensions/AJAXPoll \
 	&& git checkout -q 8429d8d4cba5be6df04e3fec17b0daabbf10cfa7 \
 	# AntiSpoof
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/AntiSpoof $MW_HOME/extensions/AntiSpoof \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-AntiSpoof $MW_HOME/extensions/AntiSpoof \
 	&& cd $MW_HOME/extensions/AntiSpoof \
 	&& git checkout -q 01cf89a678d5bab6610d24e07d3534356a5880cb \
 	# ApprovedRevs (v. 1.8.1)
-	&& git clone --single-branch -b master https://gerrit.wikimedia.org/r/mediawiki/extensions/ApprovedRevs $MW_HOME/extensions/ApprovedRevs \
+	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-ApprovedRevs $MW_HOME/extensions/ApprovedRevs \
 	&& cd $MW_HOME/extensions/ApprovedRevs \
 	&& git checkout -q a8cb4bd840465a7db1e10654a0969cfc961d8428 \
 	# Arrays
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Arrays $MW_HOME/extensions/Arrays \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Arrays $MW_HOME/extensions/Arrays \
 	&& cd $MW_HOME/extensions/Arrays \
 	&& git checkout -q 338f661bf0ab377f70e029079f2c5c5b370219df \
 	# BetaFeatures
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/BetaFeatures $MW_HOME/extensions/BetaFeatures \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-BetaFeatures $MW_HOME/extensions/BetaFeatures \
 	&& cd $MW_HOME/extensions/BetaFeatures \
 	&& git checkout -q 09cca44341f9695446c4e9fc9e8fec3fdcb197b0 \
 	# BreadCrumbs2
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/BreadCrumbs2 $MW_HOME/extensions/BreadCrumbs2 \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-BreadCrumbs2 $MW_HOME/extensions/BreadCrumbs2 \
 	&& cd $MW_HOME/extensions/BreadCrumbs2 \
 	&& git checkout -q d53357a6839e94800a617de4fc451b6c64d0a1c8 \
 	# Cargo (v. 3.4.1)
-	&& git clone --single-branch -b master https://gerrit.wikimedia.org/r/mediawiki/extensions/Cargo $MW_HOME/extensions/Cargo \
+	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-Cargo $MW_HOME/extensions/Cargo \
 	&& cd $MW_HOME/extensions/Cargo \
 	&& git checkout -q 04bfe84ef4dc806eab0ec52b361a78542d799474 \
 	# CharInsert
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/CharInsert $MW_HOME/extensions/CharInsert \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-CharInsert $MW_HOME/extensions/CharInsert \
 	&& cd $MW_HOME/extensions/CharInsert \
 	&& git checkout -q 54c0f0ca9119a3ce791fb5d53edd4ec32035a5c5 \
 	# CheckUser
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/CheckUser $MW_HOME/extensions/CheckUser \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-CheckUser $MW_HOME/extensions/CheckUser \
 	&& cd $MW_HOME/extensions/CheckUser \
 	&& git checkout -q 9e2b6d3e928855247700146273d8131e025de918 \
 	# CirrusSearch
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/CirrusSearch $MW_HOME/extensions/CirrusSearch \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-CirrusSearch $MW_HOME/extensions/CirrusSearch \
 	&& cd $MW_HOME/extensions/CirrusSearch \
 	&& git checkout -q 8296300873aaffe815800cf05c84fa04c8cbd2c0 \
 	# CodeMirror
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/CodeMirror $MW_HOME/extensions/CodeMirror \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-CodeMirror $MW_HOME/extensions/CodeMirror \
 	&& cd $MW_HOME/extensions/CodeMirror \
 	&& git checkout -q 27efed79972ca181a194d17f4a94f4192fd5a493 \
 	# Collection
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Collection $MW_HOME/extensions/Collection \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Collection $MW_HOME/extensions/Collection \
 	&& cd $MW_HOME/extensions/Collection \
 	&& git checkout -q e00e70c6fcec963c8876e410e52c83c75ed60827 \
 	# CommentStreams
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/CommentStreams $MW_HOME/extensions/CommentStreams \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-CommentStreams $MW_HOME/extensions/CommentStreams \
 	&& cd $MW_HOME/extensions/CommentStreams \
 	&& git checkout -q 274bb10bc2d39fd137650dbc0dfc607c766d1aaa \
 	# CommonsMetadata
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/CommonsMetadata $MW_HOME/extensions/CommonsMetadata \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-CommonsMetadata $MW_HOME/extensions/CommonsMetadata \
 	&& cd $MW_HOME/extensions/CommonsMetadata \
 	&& git checkout -q 8ee30de3b1cabbe55c484839127493fd5fa5d076 \
 	# ConfirmAccount
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/ConfirmAccount $MW_HOME/extensions/ConfirmAccount \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-ConfirmAccount $MW_HOME/extensions/ConfirmAccount \
 	&& cd $MW_HOME/extensions/ConfirmAccount \
 	&& git checkout -q c06d5dfb43811a2dee99099476c57af2b6d762c4 \
 	# ContactPage
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/ContactPage $MW_HOME/extensions/ContactPage \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-ContactPage $MW_HOME/extensions/ContactPage \
 	&& cd $MW_HOME/extensions/ContactPage \
 	&& git checkout -q f509796056ae1fc597b6e3c3c268fac35bf66636 \
 	# ContributionScores
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/ContributionScores $MW_HOME/extensions/ContributionScores \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-ContributionScores $MW_HOME/extensions/ContributionScores \
 	&& cd $MW_HOME/extensions/ContributionScores \
 	&& git checkout -q e307850555ef313f623dde6e2f1d5d2a43663730 \
 	# CookieWarning
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/CookieWarning $MW_HOME/extensions/CookieWarning \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-CookieWarning $MW_HOME/extensions/CookieWarning \
 	&& cd $MW_HOME/extensions/CookieWarning \
 	&& git checkout -q bc991e93133bd69fe45e07b3d4554225decc7dae \
 	# DataTransfer
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/DataTransfer $MW_HOME/extensions/DataTransfer \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-DataTransfer $MW_HOME/extensions/DataTransfer \
 	&& cd $MW_HOME/extensions/DataTransfer \
 	&& git checkout -q 2f9f949f71f0bb7d1bd8b6b97c795b9428bb1c71 \
 	# DeleteBatch
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/DeleteBatch $MW_HOME/extensions/DeleteBatch \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-DeleteBatch $MW_HOME/extensions/DeleteBatch \
 	&& cd $MW_HOME/extensions/DeleteBatch \
 	&& git checkout -q 82078d60fc59a718f429ddebe5e99de8a8734413 \
 	# Description2
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Description2 $MW_HOME/extensions/Description2 \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Description2 $MW_HOME/extensions/Description2 \
 	&& cd $MW_HOME/extensions/Description2 \
 	&& git checkout -q d2a5322a44f940de873050573e35fba4eb3063f8 \
 	# Disambiguator
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Disambiguator $MW_HOME/extensions/Disambiguator \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Disambiguator $MW_HOME/extensions/Disambiguator \
 	&& cd $MW_HOME/extensions/Disambiguator \
 	&& git checkout -q b7e7fad5f9f3dccfb902a3cbfd3bf2b16df91871 \
 	# DismissableSiteNotice
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/DismissableSiteNotice $MW_HOME/extensions/DismissableSiteNotice \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-DismissableSiteNotice $MW_HOME/extensions/DismissableSiteNotice \
 	&& cd $MW_HOME/extensions/DismissableSiteNotice \
 	&& git checkout -q 88129f80f077ec9e4932148056c8cfc1ed0361c7 \
 	# DisplayTitle
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/DisplayTitle $MW_HOME/extensions/DisplayTitle \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-DisplayTitle $MW_HOME/extensions/DisplayTitle \
 	&& cd $MW_HOME/extensions/DisplayTitle \
 	&& git checkout -q a14c406cc273c73a12957b55a27c095ad98d1795 \
 	# Echo
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Echo $MW_HOME/extensions/Echo \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Echo $MW_HOME/extensions/Echo \
 	&& cd $MW_HOME/extensions/Echo \
 	&& git checkout -q fdbc2cafdc412dc60d4345511defe9ee393efecf \
 	# Editcount
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Editcount $MW_HOME/extensions/Editcount \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Editcount $MW_HOME/extensions/Editcount \
 	&& cd $MW_HOME/extensions/Editcount \
 	&& git checkout -q 41544ffceb1356f91575dc6772a48b172751d7cc \
 	# Elastica
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Elastica $MW_HOME/extensions/Elastica \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Elastica $MW_HOME/extensions/Elastica \
 	&& cd $MW_HOME/extensions/Elastica \
 	&& git checkout -q e4ead38b71ed4f3df8dc689fe448b749771b4ed4 \
 	# EmailAuthorization
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/EmailAuthorization $MW_HOME/extensions/EmailAuthorization \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-EmailAuthorization $MW_HOME/extensions/EmailAuthorization \
 	&& cd $MW_HOME/extensions/EmailAuthorization \
 	&& git checkout -q 2016da1b354f741d89b5dc207d4a84e11ffe9bce \
 	# EmbedVideo
@@ -251,35 +251,35 @@ RUN set -x; \
 	&& cd $MW_HOME/extensions/EmbedVideo \
 	&& git checkout -q 954af96d3744d8adc7ff6458a05e579784f2d991 \
 	# EventLogging
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/EventLogging $MW_HOME/extensions/EventLogging \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-EventLogging $MW_HOME/extensions/EventLogging \
 	&& cd $MW_HOME/extensions/EventLogging \
 	&& git checkout -q 2740dbcd139be279ca2a4db039739b4f796b4178 \
 	# EventStreamConfig
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/EventStreamConfig $MW_HOME/extensions/EventStreamConfig \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-EventStreamConfig $MW_HOME/extensions/EventStreamConfig \
 	&& cd $MW_HOME/extensions/EventStreamConfig \
 	&& git checkout -q 1aae8cb6c312e49f0126091a59a453cb224657f9 \
 	# ExternalData (v. 3.2)
-	&& git clone --single-branch -b master https://gerrit.wikimedia.org/r/mediawiki/extensions/ExternalData $MW_HOME/extensions/ExternalData \
+	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-ExternalData $MW_HOME/extensions/ExternalData \
 	&& cd $MW_HOME/extensions/ExternalData \
 	&& git checkout -q 5d30e60a65ca53a3fb5b39826deb2e6917892e22 \
 	# FlexDiagrams
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/FlexDiagrams $MW_HOME/extensions/FlexDiagrams \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-FlexDiagrams $MW_HOME/extensions/FlexDiagrams \
 	&& cd $MW_HOME/extensions/FlexDiagrams \
 	&& git checkout -q 550d0de3e2525d42952d7bc9d291b26455fe07ce \
 	# GlobalNotice
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/GlobalNotice $MW_HOME/extensions/GlobalNotice \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-GlobalNotice $MW_HOME/extensions/GlobalNotice \
 	&& cd $MW_HOME/extensions/GlobalNotice \
 	&& git checkout -q 15a40bff4641f00a5a8dda3d36795b1c659c19a7 \
 	# GoogleAnalyticsMetrics
-	&& git clone --single-branch -b master https://gerrit.wikimedia.org/r/mediawiki/extensions/GoogleAnalyticsMetrics $MW_HOME/extensions/GoogleAnalyticsMetrics \
+	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-GoogleAnalyticsMetrics $MW_HOME/extensions/GoogleAnalyticsMetrics \
 	&& cd $MW_HOME/extensions/GoogleAnalyticsMetrics \
 	&& git checkout -q 82a08cc63ec58698f144be7c2fb1a6f861cb57bd \
 	# GoogleDocCreator
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/GoogleDocCreator $MW_HOME/extensions/GoogleDocCreator \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-GoogleDocCreator $MW_HOME/extensions/GoogleDocCreator \
 	&& cd $MW_HOME/extensions/GoogleDocCreator \
 	&& git checkout -q 9e53ecfa4149688a2352a7898c2a2005632e1b7d \
 	# Graph
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Graph $MW_HOME/extensions/Graph \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Graph $MW_HOME/extensions/Graph \
 	&& cd $MW_HOME/extensions/Graph \
 	&& git checkout -q 9c229eafdf406c95a4a666a6b7f2a9d0d3d682e4 \
 	# HeaderFooter
@@ -287,131 +287,131 @@ RUN set -x; \
 	&& cd $MW_HOME/extensions/HeaderFooter \
 	&& git checkout -q eee7d2c1a3373c7d6b326fd460e5d4859dd22c40 \
 	# HeaderTabs (v2.2)
-	&& git clone --single-branch -b master https://gerrit.wikimedia.org/r/mediawiki/extensions/HeaderTabs $MW_HOME/extensions/HeaderTabs \
+	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-HeaderTabs $MW_HOME/extensions/HeaderTabs \
 	&& cd $MW_HOME/extensions/HeaderTabs \
 	&& git checkout -q 42aaabf1deeb0a228fc99e578ff7ec925e560dd7 \
 	# HTMLTags
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/HTMLTags $MW_HOME/extensions/HTMLTags \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-HTMLTags $MW_HOME/extensions/HTMLTags \
 	&& cd $MW_HOME/extensions/HTMLTags \
 	&& git checkout -q b8cb3131c5e76f5c037c8474fe14e51f2e877f03 \
 	# LabeledSectionTransclusion
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/LabeledSectionTransclusion $MW_HOME/extensions/LabeledSectionTransclusion \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-LabeledSectionTransclusion $MW_HOME/extensions/LabeledSectionTransclusion \
 	&& cd $MW_HOME/extensions/LabeledSectionTransclusion \
 	&& git checkout -q 187abfeaafbad35eed4254f7a7ee0638980e932a \
 	# LDAPAuthentication2
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/LDAPAuthentication2 $MW_HOME/extensions/LDAPAuthentication2 \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-LDAPAuthentication2 $MW_HOME/extensions/LDAPAuthentication2 \
 	&& cd $MW_HOME/extensions/LDAPAuthentication2 \
 	&& git checkout -q 6bc584893d3157d5180e0e3ed93c3dbbc5b93056 \
 	# LDAPAuthorization
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/LDAPAuthorization $MW_HOME/extensions/LDAPAuthorization \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-LDAPAuthorization $MW_HOME/extensions/LDAPAuthorization \
 	&& cd $MW_HOME/extensions/LDAPAuthorization \
 	&& git checkout -q e6815d29c22f4b4eb85f868372a729ad49d7d3c8 \
 	# LDAPProvider
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/LDAPProvider $MW_HOME/extensions/LDAPProvider \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-LDAPProvider $MW_HOME/extensions/LDAPProvider \
 	&& cd $MW_HOME/extensions/LDAPProvider \
 	&& git checkout -q 80f8cc8156b0cd250d0dfacd9378ed0db7c2091d \
 	# Lingo
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Lingo $MW_HOME/extensions/Lingo \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Lingo $MW_HOME/extensions/Lingo \
 	&& cd $MW_HOME/extensions/Lingo \
 	&& git checkout -q a291fa25822097a4a2aefff242a876edadb535a4 \
 	# LinkSuggest
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/LinkSuggest $MW_HOME/extensions/LinkSuggest \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-LinkSuggest $MW_HOME/extensions/LinkSuggest \
 	&& cd $MW_HOME/extensions/LinkSuggest \
 	&& git checkout -q 6005d191e35d1d6bed5a4e7bd1bedc5fa0030bf1 \
 	# LinkTarget
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/LinkTarget $MW_HOME/extensions/LinkTarget \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-LinkTarget $MW_HOME/extensions/LinkTarget \
 	&& cd $MW_HOME/extensions/LinkTarget \
 	&& git checkout -q e5d592dcc72a00e06604ee3f65dfb8f99977c156 \
 	# Linter
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Linter $MW_HOME/extensions/Linter \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Linter $MW_HOME/extensions/Linter \
 	&& cd $MW_HOME/extensions/Linter \
 	&& git checkout -q 8bc1727955da7468f096aa5c5b5790923db43d20 \
 	# LockAuthor
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/LockAuthor $MW_HOME/extensions/LockAuthor \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-LockAuthor $MW_HOME/extensions/LockAuthor \
 	&& cd $MW_HOME/extensions/LockAuthor \
 	&& git checkout -q 4ebc4f221a0987b64740014a9380e9c3522f271d \
 	# Lockdown
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Lockdown $MW_HOME/extensions/Lockdown \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Lockdown $MW_HOME/extensions/Lockdown \
 	&& cd $MW_HOME/extensions/Lockdown \
 	&& git checkout -q ffcb6e8892ad35bb731fad1dc24712a245ab86d0 \
 	# LookupUser
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/LookupUser $MW_HOME/extensions/LookupUser \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-LookupUser $MW_HOME/extensions/LookupUser \
 	&& cd $MW_HOME/extensions/LookupUser \
 	&& git checkout -q 5fa17d449b6bedb3e8cee5b239af6cadae31da70 \
 	# Loops
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Loops $MW_HOME/extensions/Loops \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Loops $MW_HOME/extensions/Loops \
 	&& cd $MW_HOME/extensions/Loops \
 	&& git checkout -q 0eb05a81b9b53f5381eefb4f8b6959b6dcdec1d8 \
 	# MagicNoCache
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/MagicNoCache $MW_HOME/extensions/MagicNoCache \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-MagicNoCache $MW_HOME/extensions/MagicNoCache \
 	&& cd $MW_HOME/extensions/MagicNoCache \
 	&& git checkout -q 93534c12dac0e821c46c94b21053d274a6e557de \
 	# MassMessage
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/MassMessage $MW_HOME/extensions/MassMessage \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-MassMessage $MW_HOME/extensions/MassMessage \
 	&& cd $MW_HOME/extensions/MassMessage \
 	&& git checkout -q d6a86291bb975c3dc7778f370006f1145cc834bd \
 	# MassMessageEmail
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/MassMessageEmail $MW_HOME/extensions/MassMessageEmail \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-MassMessageEmail $MW_HOME/extensions/MassMessageEmail \
 	&& cd $MW_HOME/extensions/MassMessageEmail \
 	&& git checkout -q edd96f14c6d108d56bcecb18b5bb7b3355437732 \
 	# MediaUploader
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/MediaUploader $MW_HOME/extensions/MediaUploader \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-MediaUploader $MW_HOME/extensions/MediaUploader \
 	&& cd $MW_HOME/extensions/MediaUploader \
 	&& git checkout -q 1edd91c506c1c0319e7b9a3e71d639130760b1fd \
 	# MintyDocs (1.0)
-	&& git clone --single-branch -b master https://gerrit.wikimedia.org/r/mediawiki/extensions/MintyDocs $MW_HOME/extensions/MintyDocs \
+	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-MintyDocs $MW_HOME/extensions/MintyDocs \
 	&& cd $MW_HOME/extensions/MintyDocs \
 	&& git checkout -q 4496e33ce71d2c364b16599619c961a1a330bf14 \
 	# MobileFrontend
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/MobileFrontend $MW_HOME/extensions/MobileFrontend \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-MobileFrontend $MW_HOME/extensions/MobileFrontend \
 	&& cd $MW_HOME/extensions/MobileFrontend \
 	&& git checkout -q f0bed5588f76b827038fb9af73fb9677e5804077 \
 	# MsUpload
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/MsUpload $MW_HOME/extensions/MsUpload \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-MsUpload $MW_HOME/extensions/MsUpload \
 	&& cd $MW_HOME/extensions/MsUpload \
 	&& git checkout -q dac2376a2fac6ddf4b2038db9b4bc06092ecaa15 \
 	# MyVariables
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/MyVariables $MW_HOME/extensions/MyVariables \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-MyVariables $MW_HOME/extensions/MyVariables \
 	&& cd $MW_HOME/extensions/MyVariables \
 	&& git checkout -q 8b45be10c9b0a484824c55d8cc48399290384260 \
 	# NewUserMessage
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/NewUserMessage $MW_HOME/extensions/NewUserMessage \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-NewUserMessage $MW_HOME/extensions/NewUserMessage \
 	&& cd $MW_HOME/extensions/NewUserMessage \
 	&& git checkout -q 206f32880fa7bf70b191d33ed80b8626bca39efe \
 	# NumerAlpha
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/NumerAlpha $MW_HOME/extensions/NumerAlpha \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-NumerAlpha $MW_HOME/extensions/NumerAlpha \
 	&& cd $MW_HOME/extensions/NumerAlpha \
 	&& git checkout -q 93c0869735581006a3f510096738e262d49f4107 \
 	# OpenGraphMeta
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/OpenGraphMeta $MW_HOME/extensions/OpenGraphMeta \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-OpenGraphMeta $MW_HOME/extensions/OpenGraphMeta \
 	&& cd $MW_HOME/extensions/OpenGraphMeta \
 	&& git checkout -q d319702cd4ceda1967c233ef8e021b67b3fc355f \
 	# OpenIDConnect
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/OpenIDConnect $MW_HOME/extensions/OpenIDConnect \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-OpenIDConnect $MW_HOME/extensions/OpenIDConnect \
 	&& cd $MW_HOME/extensions/OpenIDConnect \
 	&& git checkout -q 0824f3cf3800f63e930abf0f03baf1a7c755a270 \
 	# PageExchange
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/PageExchange $MW_HOME/extensions/PageExchange \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-PageExchange $MW_HOME/extensions/PageExchange \
 	&& cd $MW_HOME/extensions/PageExchange \
 	&& git checkout -q 28482410564e38d2b97ab7321e99c4281c6e5877 \
 	# PageForms (v. 5.6)
-	&& git clone --single-branch -b master https://gerrit.wikimedia.org/r/mediawiki/extensions/PageForms $MW_HOME/extensions/PageForms \
+	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-PageForms $MW_HOME/extensions/PageForms \
 	&& cd $MW_HOME/extensions/PageForms \
 	&& git checkout -q d9b0e47a83d951c585f95c97ea10ea8be95adec9 \
 	# PluggableAuth
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/PluggableAuth $MW_HOME/extensions/PluggableAuth \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-PluggableAuth $MW_HOME/extensions/PluggableAuth \
 	&& cd $MW_HOME/extensions/PluggableAuth \
 	&& git checkout -q 4be1e402e1862d165a4feb003c492ddc9525057e \
 	# Popups
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Popups $MW_HOME/extensions/Popups \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Popups $MW_HOME/extensions/Popups \
 	&& cd $MW_HOME/extensions/Popups \
 	&& git checkout -q ff4d2156e1f7f4c11f7396cb0cd70d387abd8187 \
 	# RegularTooltips
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/RegularTooltips $MW_HOME/extensions/RegularTooltips \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-RegularTooltips $MW_HOME/extensions/RegularTooltips \
 	&& cd $MW_HOME/extensions/RegularTooltips \
 	&& git checkout -q 1af807bb6d5cfbd1e471e38bf70d6a392fb7eda2 \
 	# RevisionSlider
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/RevisionSlider $MW_HOME/extensions/RevisionSlider \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-RevisionSlider $MW_HOME/extensions/RevisionSlider \
 	&& cd $MW_HOME/extensions/RevisionSlider \
 	&& git checkout -q 3cae51a322a5ca0f359e83efcb5fac38e73e346e \
 	# RottenLinks
@@ -419,11 +419,11 @@ RUN set -x; \
 	&& cd $MW_HOME/extensions/RottenLinks \
 	&& git checkout -q a96e99d0a61a42d59587a67db0720ce245a7ee46 \
 	# SandboxLink
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/SandboxLink $MW_HOME/extensions/SandboxLink \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-SandboxLink $MW_HOME/extensions/SandboxLink \
 	&& cd $MW_HOME/extensions/SandboxLink \
 	&& git checkout -q 9ab23288a010c3894c59cd5ba3096d93d57c15c5 \
 	# SaveSpinner
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/SaveSpinner $MW_HOME/extensions/SaveSpinner \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-SaveSpinner $MW_HOME/extensions/SaveSpinner \
 	&& cd $MW_HOME/extensions/SaveSpinner \
 	&& git checkout -q 1e819e2fff7fad6999bafe71d866c3af50836c42 \
 	# SemanticDependencyUpdater (v. 2.0.2)
@@ -435,7 +435,7 @@ RUN set -x; \
 	&& cd $MW_HOME/extensions/SemanticDrilldown \
 	&& git checkout -q e960979ec5a3b1e662b3742cee7e7ef4056f9a46 \
 	# SimpleChanges
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/SimpleChanges $MW_HOME/extensions/SimpleChanges \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-SimpleChanges $MW_HOME/extensions/SimpleChanges \
 	&& cd $MW_HOME/extensions/SimpleChanges \
 	&& git checkout -q 5352de89dfaf043f646a44582b26f07822f02be7 \
 	# SimpleMathJax
@@ -443,103 +443,103 @@ RUN set -x; \
 	&& cd $MW_HOME/extensions/SimpleMathJax \
 	&& git checkout -q 3757e9b1cf235b2e2c62e7d208d52206e185b28e \
 	# SkinPerPage
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/SkinPerPage $MW_HOME/extensions/SkinPerPage \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-SkinPerPage $MW_HOME/extensions/SkinPerPage \
 	&& cd $MW_HOME/extensions/SkinPerPage \
 	&& git checkout -q 2793602b37c33aa4c769834feac0b88f385ccef9 \
 	# SmiteSpam
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/SmiteSpam $MW_HOME/extensions/SmiteSpam \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-SmiteSpam $MW_HOME/extensions/SmiteSpam \
 	&& cd $MW_HOME/extensions/SmiteSpam \
 	&& git checkout -q 268f212b7e366711d8e7b54c7faf5b750fa014ad \
 	# SocialProfile
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/SocialProfile $MW_HOME/extensions/SocialProfile \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-SocialProfile $MW_HOME/extensions/SocialProfile \
 	&& cd $MW_HOME/extensions/SocialProfile \
 	&& git checkout -q 74fcf9bead948ec0419eea10800c9331bcc1273e \
 	# TemplateStyles
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/TemplateStyles $MW_HOME/extensions/TemplateStyles \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-TemplateStyles $MW_HOME/extensions/TemplateStyles \
 	&& cd $MW_HOME/extensions/TemplateStyles \
 	&& git checkout -q 2a93b56e370ab8b8e020ed29c507104b56f1d11a \
 	# TemplateWizard
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/TemplateWizard $MW_HOME/extensions/TemplateWizard \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-TemplateWizard $MW_HOME/extensions/TemplateWizard \
 	&& cd $MW_HOME/extensions/TemplateWizard \
 	&& git checkout -q d486e3475f84118fd9b5c77d60254daa2f56f654 \
 	# Thanks
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Thanks $MW_HOME/extensions/Thanks \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Thanks $MW_HOME/extensions/Thanks \
 	&& cd $MW_HOME/extensions/Thanks \
 	&& git checkout -q 03b6a52f263604c819e69b78c157f6ef5adb053e \
 	# TimedMediaHandler
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/TimedMediaHandler $MW_HOME/extensions/TimedMediaHandler \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-TimedMediaHandler $MW_HOME/extensions/TimedMediaHandler \
 	&& cd $MW_HOME/extensions/TimedMediaHandler \
 	&& git checkout -q 2e64302c68e58693650e91b7869fa5aecf1aaf23 \
 	# TinyMCE
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/TinyMCE $MW_HOME/extensions/TinyMCE \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-TinyMCE $MW_HOME/extensions/TinyMCE \
 	&& cd $MW_HOME/extensions/TinyMCE \
 	&& git checkout -q 06436ec3a53c6cd53c458e4e8ab3ec8d1a23029b \
 	# TitleIcon
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/TitleIcon $MW_HOME/extensions/TitleIcon \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-TitleIcon $MW_HOME/extensions/TitleIcon \
 	&& cd $MW_HOME/extensions/TitleIcon \
 	&& git checkout -q 7c6c83f4859642542393612ad961a258378e0cac \
 	# UniversalLanguageSelector
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/UniversalLanguageSelector $MW_HOME/extensions/UniversalLanguageSelector \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector $MW_HOME/extensions/UniversalLanguageSelector \
 	&& cd $MW_HOME/extensions/UniversalLanguageSelector \
 	&& git checkout -q 8216e434c38ddeba74e5ad758bfbbcc83861fa60 \
 	# UploadWizard
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/UploadWizard $MW_HOME/extensions/UploadWizard \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-UploadWizard $MW_HOME/extensions/UploadWizard \
 	&& cd $MW_HOME/extensions/UploadWizard \
 	&& git checkout -q 847413694b519c76da7196023651c8d584137d2f \
 	# UrlGetParameters
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/UrlGetParameters $MW_HOME/extensions/UrlGetParameters \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-UrlGetParameters $MW_HOME/extensions/UrlGetParameters \
 	&& cd $MW_HOME/extensions/UrlGetParameters \
 	&& git checkout -q d36f92810c762b301035ff1b4f42792ed9a1018b \
 	# UserFunctions
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/UserFunctions $MW_HOME/extensions/UserFunctions \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-UserFunctions $MW_HOME/extensions/UserFunctions \
 	&& cd $MW_HOME/extensions/UserFunctions \
 	&& git checkout -q b532b1047080c3738327ee2f3b541e563e06ca19 \
 	# UserMerge
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/UserMerge $MW_HOME/extensions/UserMerge \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-UserMerge $MW_HOME/extensions/UserMerge \
 	&& cd $MW_HOME/extensions/UserMerge \
 	&& git checkout -q 183bb7a8f78cbe365bec0fbd4b3ecdd4fae1a359 \
 	# UserPageViewTracker (v. 0.7)
-	&& git clone --single-branch -b master https://gerrit.wikimedia.org/r/mediawiki/extensions/UserPageViewTracker $MW_HOME/extensions/UserPageViewTracker \
+	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-UserPageViewTracker $MW_HOME/extensions/UserPageViewTracker \
 	&& cd $MW_HOME/extensions/UserPageViewTracker \
 	&& git checkout -q f4b7c20c372165541164d449c12df1e74e98ed0b \
 	# Variables
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Variables $MW_HOME/extensions/Variables \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Variables $MW_HOME/extensions/Variables \
 	&& cd $MW_HOME/extensions/Variables \
 	&& git checkout -q b4a9063f16a928567e3b6788cda9246c2e94797f \
 	# VEForAll (v. 0.4.1)
-	&& git clone --single-branch -b master https://gerrit.wikimedia.org/r/mediawiki/extensions/VEForAll $MW_HOME/extensions/VEForAll \
+	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-VEForAll $MW_HOME/extensions/VEForAll \
 	&& cd $MW_HOME/extensions/VEForAll \
 	&& git checkout -q 2f1f08eca7fbf61198e5f4ccf2d627a6c9ef7b64 \
 	# VoteNY
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/VoteNY $MW_HOME/extensions/VoteNY \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-VoteNY $MW_HOME/extensions/VoteNY \
 	&& cd $MW_HOME/extensions/VoteNY \
 	&& git checkout -q 11c103f4b9167a8d8d5e850d8a781c6f49b249c1 \
 	# WatchAnalytics (v. 3.2.0)
-	&& git clone --single-branch -b master https://gerrit.wikimedia.org/r/mediawiki/extensions/WatchAnalytics $MW_HOME/extensions/WatchAnalytics \
+	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-WatchAnalytics $MW_HOME/extensions/WatchAnalytics \
 	&& cd $MW_HOME/extensions/WatchAnalytics \
 	&& git checkout -q f6e4d07a93baf502358ce0af01c0ac7e59cc6f4b \
 	# WhoIsWatching
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/WhoIsWatching $MW_HOME/extensions/WhoIsWatching \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-WhoIsWatching $MW_HOME/extensions/WhoIsWatching \
 	&& cd $MW_HOME/extensions/WhoIsWatching \
 	&& git checkout -q 836a31018e26ab7c993088c4cca31a89efec2ee5 \
 	# WhosOnline
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/WhosOnline $MW_HOME/extensions/WhosOnline \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-WhosOnline $MW_HOME/extensions/WhosOnline \
 	&& cd $MW_HOME/extensions/WhosOnline \
 	&& git checkout -q bb1765d2eb5c88ca10dc8a0be19f35fcffdccdae \
 	# Widgets
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Widgets $MW_HOME/extensions/Widgets \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Widgets $MW_HOME/extensions/Widgets \
 	&& cd $MW_HOME/extensions/Widgets \
 	&& git checkout -q 197d429f971b2aebbce29b7a91a194e1f8181e64 \
 	# WikiForum
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/WikiForum $MW_HOME/extensions/WikiForum \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-WikiForum $MW_HOME/extensions/WikiForum \
 	&& cd $MW_HOME/extensions/WikiForum \
 	&& git checkout -q a2685b60af86890f199a5f3b6581918369e6a571 \
 	# WikiSEO
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/WikiSEO $MW_HOME/extensions/WikiSEO \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-WikiSEO $MW_HOME/extensions/WikiSEO \
 	&& cd $MW_HOME/extensions/WikiSEO \
 	&& git checkout -q 610cffa3345333b53d4dda7b55b2012fbfcee9de \
 	# WSOAuth
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/WSOAuth $MW_HOME/extensions/WSOAuth \
+	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-WSOAuth $MW_HOME/extensions/WSOAuth \
 	&& cd $MW_HOME/extensions/WSOAuth \
 	&& git checkout -q 3c54c4899dd63989bc3214273bf1c5807c7ac5db
 


### PR DESCRIPTION
Related Issue: #35 

This following PR replaces ``gerrit``  with ``github`` when extensions and skins are cloned

## Areas of discussion
A github mirror for ``SemanticDrilldown`` extension was not found on wikimedia's official github account. However, an alternative was found [here](https://github.com/SemanticMediaWiki/SemanticDrilldown) . The same can replace current SemanticDrillDown gerrit if approved.

## Changes made

Dockerfile gets built successfully after replacing  ``gerrit``  with ``github mirrors``

![image](https://user-images.githubusercontent.com/76606666/223368155-4da52333-3dc1-41b7-8610-e99639f2d885.png)
