### PR TITLE
Fix for SiteNoticeAfter code for nonexistent special pages

### DIFF
--- a/_sources/canasta/CanastaUtils.php
+++ b/_sources/canasta/CanastaUtils.php
@@ -39,6 +39,9 @@ $wgHooks['SiteNoticeAfter'][] = function ( &$siteNotice, Skin $skin ) {
 	$specialPage = MediaWiki\MediaWikiServices::getInstance()
 		->getSpecialPageFactory()
 		->getPage( $title->getText() );
+	if ( $specialPage == null ) {
+		return;
+	}
 	$canonicalName = $specialPage->getName();
 	// Only display this warning for pages that could result in an email getting sent.
 	$specialPagesWithEmail = [ 'Preferences', 'CreateAccount' ];


### PR DESCRIPTION
Going to a nonexistent special page, like Special:Blah, led to an error message instead of the standard display, because of the lack of a "null" check in the Canasta SMTP-handling code.