### PR TITLE
Fix for case when web container can't start after incompletely-shutdown

### DIFF
--- a/_sources/scripts/run-apache.sh
+++ b/_sources/scripts/run-apache.sh
@@ -199,6 +199,6 @@ inotifywait &
 # Make sure we're not confused by old, incompletely-shutdown httpd
 # context after restarting the container.  httpd won't start correctly
 # if it thinks it is already running.
-rm -rf /run/httpd/* /tmp/httpd*
+rm -rf /run/apache2/* /tmp/apache2*
 
 exec /usr/sbin/apachectl -DFOREGROUND


### PR DESCRIPTION
The patch to the pid file was not changed when the base image was changed
  from centos to debian.