### PR TITLE
Re-add GTag extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -552,6 +552,12 @@ RUN set -x; \
 	&& cd $MW_HOME/extensions/WSOAuth \
 	&& git checkout -q 3c54c4899dd63989bc3214273bf1c5807c7ac5db
 
+# GTag
+COPY _sources/extensions/GTag1.2.0.tar.gz /tmp/
+RUN set -x; \
+    tar -xvf /tmp/GTag*.tar.gz -C $MW_HOME/extensions \
+    && rm /tmp/GTag*.tar.gz
+
 # Patch composer
 RUN set -x; \
     sed -i 's="monolog/monolog": "2.2.0",="monolog/monolog": "^2.2",=g' $MW_HOME/composer.json


### PR DESCRIPTION
This extension's code has been contained within Canasta since the beginning (it's the one extension that Canasta actually comes bundled with, as opposed to being downloaded via Git or Composer), but it was deleted from the Dockerfile during the temporary "mass deletion" in October 2022:

https://github.com/CanastaWiki/Canasta/commit/3e6d38d401782e0c66cc00d6cb20dc212c70f0ba

It was not re-added, though, when most of the other extensions were re-added two weeks later:

https://github.com/CanastaWiki/Canasta/commit/93e3be6946a90d4d13cddff49594108bdc07998d

I assume that was just a mistake.