### PR TITLE
Migrates HeaderFooter to Wikia fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -296,9 +296,9 @@ RUN set -x; \
 	&& cd $MW_HOME/extensions/GTag \
 	&& git checkout -q d45f54085d003166aa032363408b8dbef7dd3628 \
 	# HeaderFooter
-	&& git clone https://github.com/enterprisemediawiki/HeaderFooter.git $MW_HOME/extensions/HeaderFooter \
+	&& git clone https://github.com/Wikia/HeaderFooter.git $MW_HOME/extensions/HeaderFooter \
 	&& cd $MW_HOME/extensions/HeaderFooter \
-	&& git checkout -q eee7d2c1a3373c7d6b326fd460e5d4859dd22c40 \
+	&& git checkout -q 0f582dd1ddf2d3e79907e064e68534eeff76be90 \
 	# HeaderTabs (v2.2)
 	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-HeaderTabs $MW_HOME/extensions/HeaderTabs \
 	&& cd $MW_HOME/extensions/HeaderTabs \


### PR DESCRIPTION
Enterprisemediawiki version is broken on 1.39, this commit migrates the extension to Wikia version (REL1_39) branch

Solves #267