### PR TITLE
Allow modification to default composer installed extensions

### DIFF
--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -1,21 +1,8 @@
 {
-	"require": {
-		"mediawiki/chameleon-skin": "~4.0",
-		"mediawiki/maps": "10.0.0",
-		"mediawiki/mermaid": "~3.1",
-		"mediawiki/semantic-media-wiki": "4.1.1",
-		"mediawiki/semantic-result-formats": "4.0.2",
-		"mediawiki/semantic-breadcrumb-links": "2.1.x-dev",
-		"mediawiki/semantic-compound-queries": "~2.2",
-		"mediawiki/semantic-extra-special-properties": "3.0.2",
-		"mediawiki/semantic-scribunto": "2.2.0",
-		"mediawiki/simple-batch-upload": "1.8.2",
-		"mediawiki/bootstrap-components": "^5.0",
-		"mediawiki/sub-page-list": "2.0.2"
-	},
 	"extra": {
 		"merge-plugin": {
 			"include": [
+				"/mediawiki/config/composer.local.json",
 				"extensions/AbuseFilter/composer.json",
 				"extensions/CirrusSearch/composer.json",
 				"extensions/DataTransfer/composer.json",


### PR DESCRIPTION
Move composer installed extensions to volumed in composer.local.json file.
Add support for specifying an alternative composer.local.json file at create/import time.

Depends on CanastaWiki/Canasta-DockerCompose#47
Both pull requests must be merged together.

Optionally extended by CanastaWiki/Canasta-CLI#94, but that pull request does not need to be merged at the same time.
