### PR TITLE
Remove SemanticFormsSelect, Semantic Tasks from composer.canasta.json

### DIFF
--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -14,9 +14,7 @@
 				"extensions/Widgets/composer.json",
 				"extensions/GoogleAnalyticsMetrics/composer.json",
 				"extensions/OpenIDConnect/composer.json",
-				"extensions/WSOAuth/composer.json",
-				"extensions/SemanticFormsSelect/composer.json",
-				"extensions/SemanticTasks/composer.json"
+				"extensions/WSOAuth/composer.json"
 			]
 		}
 	}


### PR DESCRIPTION
Neither of these extensions contain any Composer dependencies that need to be downloaded.