### PR TITLE
Revert "Remove SemanticFormsSelect, Semantic Tasks from composer.canasta.json"

### DIFF
--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -14,7 +14,9 @@
 				"extensions/Widgets/composer.json",
 				"extensions/GoogleAnalyticsMetrics/composer.json",
 				"extensions/OpenIDConnect/composer.json",
-				"extensions/WSOAuth/composer.json"
+				"extensions/WSOAuth/composer.json",
+				"extensions/SemanticFormsSelect/composer.json",
+				"extensions/SemanticTasks/composer.json"
 			]
 		}
 	}


### PR DESCRIPTION
Reverts CanastaWiki/Canasta#274

It turns out that the "autoload" section of each extension's composer.json file is important too.