### PR TITLE
Re-remove SemanticFormsSelect, Semantic Tasks from composer.canasta.json

### DIFF
--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -17,9 +17,7 @@
 				"extensions/Widgets/composer.json",
 				"extensions/GoogleAnalyticsMetrics/composer.json",
 				"extensions/OpenIDConnect/composer.json",
-				"extensions/WSOAuth/composer.json",
-				"extensions/SemanticFormsSelect/composer.json",
-				"extensions/SemanticTasks/composer.json"
+				"extensions/WSOAuth/composer.json"
 			]
 		}
 	}


### PR DESCRIPTION
It turns out that their Composer "autoload" is not needed either, because their extension.json files already contain an autoload.