### PR TITLE
Remove duplicate call to install php7.4-mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ RUN set x; \
 	php7.4-gd \
 	php7.4-mbstring \
 	php7.4-xml \
-	php7.4-mysql \
 	php7.4-intl \
 	php7.4-opcache \
 	php7.4-apcu \


### PR DESCRIPTION
I assume both calls are not needed.