### PR TITLE
Canasta2.0 adding wiki farm support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN set x; \
 	php7.4-gd \
 	php7.4-mbstring \
 	php7.4-xml \
+	php7.4-mysql \
 	php7.4-intl \
 	php7.4-opcache \
 	php7.4-apcu \
@@ -60,6 +61,7 @@ RUN set x; \
 	php7.4-curl \
 	php7.4-zip \
 	php7.4-fpm \
+	php7.4-yaml \
 	libapache2-mod-fcgid \
 	&& aptitude clean \
 	&& rm -rf /var/lib/apt/lists/*
@@ -663,11 +665,11 @@ RUN set -x; \
 # Generate sample files for installing extensions and skins in LocalSettings.php
 RUN set -x; \
 	cd $MW_HOME/extensions \
-    && for i in $(ls -d */); do echo "#wfLoadExtension('${i%%/}');"; done > $MW_ORIGIN_FILES/installedExtensions.txt \
+	&& for i in $(ls -d */); do echo "#wfLoadExtension('${i%%/}');"; done > $MW_ORIGIN_FILES/installedExtensions.txt \
     # Dirty hack for Semantic MediaWiki
     && sed -i "s/#wfLoadExtension('SemanticMediaWiki');/#enableSemantics('localhost');/g" $MW_ORIGIN_FILES/installedExtensions.txt \
     && cd $MW_HOME/skins \
-    && for i in $(ls -d */); do echo "#wfLoadSkin('${i%%/}');"; done > $MW_ORIGIN_FILES/installedSkins.txt \
+	&& for i in $(ls -d */); do echo "#wfLoadSkin('${i%%/}');"; done > $MW_ORIGIN_FILES/installedSkins.txt \
     # Load Vector skin by default in the sample file
     && sed -i "s/#wfLoadSkin('Vector');/wfLoadSkin('Vector');/" $MW_ORIGIN_FILES/installedSkins.txt
 
@@ -729,8 +731,9 @@ COPY _sources/scripts/*.php $MW_HOME/maintenance/
 COPY _sources/configs/robots.txt $WWW_ROOT/
 COPY _sources/configs/.htaccess $WWW_ROOT/
 COPY _sources/images/favicon.ico $WWW_ROOT/
-COPY _sources/canasta/LocalSettings.php _sources/canasta/CanastaUtils.php _sources/canasta/CanastaDefaultSettings.php $MW_HOME/
+COPY _sources/canasta/LocalSettings.php _sources/canasta/CanastaUtils.php _sources/canasta/CanastaDefaultSettings.php _sources/canasta/FarmConfigLoader.php $MW_HOME/
 COPY _sources/canasta/getMediawikiSettings.php /
+COPY _sources/canasta/canasta_img.php $MW_HOME/ 
 COPY _sources/configs/mpm_event.conf /etc/apache2/mods-available/mpm_event.conf
 
 RUN set -x; \
@@ -745,6 +748,9 @@ RUN set -x; \
 	&& sed -i 's/MW_CONFIG_FILE/CANASTA_CONFIG_FILE/g' "$MW_HOME/includes/CanastaNoLocalSettings.php" \
 	# Modify config
 	&& sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf \
+	&& sed -i '/<Directory \/var\/www\/>/i RewriteCond %{THE_REQUEST} \\s(.*?)\\s\nRewriteRule ^ - [E=ORIGINAL_URL:%{REQUEST_SCHEME}://%{HTTP_HOST}%1]' /etc/apache2/apache2.conf \
+	&& echo "Alias /w/images/ /var/www/mediawiki/w/canasta_img.php/" >> /etc/apache2/apache2.conf \
+    && echo "Alias /w/images /var/www/mediawiki/w/canasta_img.php" >> /etc/apache2/apache2.conf \
 	&& a2enmod expires \
 	&& a2disconf other-vhosts-access-log \
 	# Enable environment variables for FPM workers

--- a/_sources/canasta/FarmConfigLoader.php
+++ b/_sources/canasta/FarmConfigLoader.php
@@ -1,0 +1,153 @@
+<?php
+
+# Protect against web entry
+if ( !defined( 'MEDIAWIKI' ) ) {
+	exit;
+}
+
+// Get the original URL from the environment variables
+$original_url = getenv( 'ORIGINAL_URL' );
+$serverName = "";
+$path = "";
+
+// Check if the original URL is defined, else throw an exception
+if ( $original_url === false && !defined( 'MW_WIKI_NAME' ) ) {
+	return;
+}
+
+// Parse the original URL
+$urlComponents = parse_url( $original_url );
+
+// Check if URL parsing was successful, else throw an exception
+if ( $urlComponents === false ) {
+	throw new Exception( 'Error: Failed to parse the original URL' );
+}
+
+// Extract the server name (host) from the URL
+if ( isset( $urlComponents['host'] ) ) {
+	$serverName = $urlComponents['host'];
+}
+
+// Extract the path from the URL, if any
+if ( isset( $urlComponents['path'] ) ) {
+	// Split the path into parts
+	$pathParts = explode( '/', trim( $urlComponents['path'], '/' ) );
+
+	// Check if path splitting was successful, else throw an exception
+	if ( $pathParts === false ) {
+		throw new Exception( 'Error: Failed to split the path into parts' );
+	}
+
+	// If there is a path, store the first directory in the variable $path
+	if ( count( $pathParts ) > 0 ) {
+		$firstDirectory = $pathParts[0];
+	}
+
+	// If the first directory is not "wiki" or "w", store it in the variable $path
+	if ( $firstDirectory != "wiki" && $firstDirectory != "w" ) {
+		$path = $firstDirectory;
+	}
+}
+
+// Parse the YAML configuration file containing the wiki information
+$wikiConfigurations = null;
+
+try {
+	// Get the file path of the YAML configuration file
+	$file = getenv( 'MW_VOLUME' ) . '/config/wikis.yaml';
+
+	// Check if the configuration file exists, else throw an exception
+	if ( !file_exists( $file ) ) {
+		throw new Exception( 'The configuration file does not exist' );
+	}
+
+	// Parse the configuration file
+	$wikiConfigurations = yaml_parse_file( $file );
+
+	// Check if file parsing was successful, else throw an exception
+	if ( $wikiConfigurations === false ) {
+		throw new Exception( 'Error parsing the configuration file' );
+	}
+} catch ( Exception $e ) {
+	die( 'Caught exception: ' . $e->getMessage() );
+}
+
+$wikiIdToConfigMap = [];
+$urlToWikiIdMap = [];
+
+// Populate the arrays with data from the configuration file
+if ( isset( $wikiConfigurations ) && isset( $wikiConfigurations['wikis'] ) && is_array( $wikiConfigurations['wikis'] ) ) {
+	foreach ( $wikiConfigurations['wikis'] as $wiki ) {
+		// Check if 'url' and 'id' are set before using them
+		if ( isset( $wiki['url'] ) && isset( $wiki['id'] ) ) {
+			$urlToWikiIdMap[$wiki['url']] = $wiki['id'];
+			$wikiIdToConfigMap[$wiki['id']] = $wiki;
+		} else {
+			throw new Exception( 'Error: The wiki configuration is missing either the url or id attribute.' );
+		}
+	}
+} else {
+	throw new Exception( 'Error: Invalid wiki configurations.' );
+}
+
+// Prepare the key using the server name and the path
+if ( empty( $path ) ) {
+	$key = $serverName;
+} else {
+	$key = $serverName . '/' . $path;
+}
+
+// Retrieve the wikiID if available
+$wikiID = defined( 'MW_WIKI_NAME' ) ? MW_WIKI_NAME : null;
+
+// Check if the key is null or if it exists in the urlToWikiIdMap, else throw an exception
+if ( $key === null ) {
+	throw new Exception( "Error: Key is null." );
+} elseif ( $wikiID === null && array_key_exists( $key, $urlToWikiIdMap ) ) {
+	$wikiID = $urlToWikiIdMap[$key];
+} elseif ( $wikiID === null ) {
+	throw new Exception( "Error: $key does not exist in urlToWikiIdMap." );
+}
+
+// Get the configuration for the selected wiki
+$selectedWikiConfig = $wikiIdToConfigMap[$wikiID] ?? null;
+
+// Check if a matching configuration was found. If so, configure the wiki database, else terminate execution
+if ( !empty( $selectedWikiConfig ) ) {
+	// Set database name to the wiki ID
+	$wgDBname = $wikiID;
+
+	// Set site name and meta namespace from the configuration, or use the wiki ID if 'name' is not set
+	$wgSitename = isset( $selectedWikiConfig['name'] ) ? $selectedWikiConfig['name'] : $wikiID;
+	$wgMetaNamespace = isset( $selectedWikiConfig['name'] ) ? $selectedWikiConfig['name'] : $wikiID;
+} else {
+	die( 'Unknown wiki.' );
+}
+
+// Configure the wiki server and URL paths
+$wgServer = "https://$serverName";
+$wgScriptPath = !empty( $path )
+	? "/$path/w"
+	: "/w";
+
+$wgArticlePath = !empty( $path )
+	? "/$path/wiki/$1"
+	: "/wiki/$1";
+$wgCacheDirectory = "$IP/cache/$wikiID";
+$wgUploadDirectory = "$IP/images/$wikiID";
+
+// Load additional configuration files specific to the wiki ID
+$files = glob( getenv( 'MW_VOLUME' ) . "/config/{$wikiID}/*.php" );
+
+$wgEnableUploads = true;
+
+// Check if the glob function was successful, else continue with the execution
+if ( $files !== false && is_array( $files ) ) {
+	// Sort the files
+	sort( $files );
+
+	// Include each file
+	foreach ( $files as $filename ) {
+		require_once "$filename";
+	}
+}

--- a/_sources/canasta/canasta_img.php
+++ b/_sources/canasta/canasta_img.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * The web entry point for serving non-public images to logged-in users in the Canasta project.
+ *
+ * This file is specifically configured for the Canasta project. In Canasta, images for each wiki
+ * are stored in their specific directories, located at /mediawiki/images/$wikiID.
+ * 
+ * This script also includes functionality for 'canasta_img', which helps in redirecting users
+ * to their corresponding image locations. If the 'wikis.yaml' file does not exist, 
+ * the script will function as originally designed.
+ *
+ * For general setup, see https://www.mediawiki.org/wiki/Manual:Image_Authorization
+ *
+ * Configuration:
+ * - Set $wgUploadDirectory to point to the non-public directory where images are stored. 
+ *   For Canasta, this would be /mediawiki/images/$wikiID.
+ * - Set $wgUploadPath to point to this file.
+ *
+ * Optional Parameters:
+ * - Set $wgImgAuthDetails = true to display denial reason messages instead of just a 403 error.
+ *   This can be useful for debugging but is generally not recommended for production use.
+ * 
+ * Server Requirements:
+ * Your server needs to support REQUEST_URI or PATH_INFO; some CGI-based configurations don't.
+ *
+ * License:
+ * This program is free software under the GNU General Public License.
+ *
+ * @file
+ * @ingroup entrypoint
+ * @author Chenhao Liu
+ */
+
+define( 'MW_NO_OUTPUT_COMPRESSION', 1 );
+define( 'MW_ENTRY_POINT', 'canasta_img' );
+require __DIR__ . '/includes/WebStart.php';
+
+wfImageAuthMain();
+
+$mediawiki = new MediaWiki();
+$mediawiki->doPostOutputShutdown();
+
+function wfImageAuthMain() {
+	global $wgImgAuthUrlPathMap, $wgScriptPath, $wgImgAuthPath, $wikiID;
+
+	$services = \MediaWiki\MediaWikiServices::getInstance();
+	$permissionManager = $services->getPermissionManager();
+
+	$request = RequestContext::getMain()->getRequest();
+	$publicWiki = in_array( 'read', $permissionManager->getGroupPermissions( [ '*' ] ), true );
+
+	// Find the path assuming the request URL is relative to the local public zone URL
+	$baseUrl = $services->getRepoGroup()->getLocalRepo()->getZoneUrl( 'public' );
+	if ( $baseUrl[0] === '/' ) {
+		$basePath = $baseUrl;
+	} else {
+		$basePath = parse_url( $baseUrl, PHP_URL_PATH );
+	}
+	$path = WebRequest::getRequestPathSuffix( $basePath );
+
+	if ( $path === false ) {
+		// Try instead assuming canasta_img.php is the base path
+		$basePath = $wgImgAuthPath ?: "$wgScriptPath/canasta_img.php";
+		$path = WebRequest::getRequestPathSuffix( $basePath );
+	}
+
+	if ( $path === false ) {
+		wfForbidden( 'img-auth-accessdenied', 'img-auth-notindir' );
+		return;
+	}
+
+	if ( $path === '' || $path[0] !== '/' ) {
+		// Make sure $path has a leading /
+		$path = "/" . $path;
+	}
+
+	if ( isset( $wikiID ) && !empty( $wikiID ) ) {
+		// Replace "/images" | "/canasta_img.php" with "/images/$wikiID" | "/canasta_img.php/$wikiID" in the path.
+		$path = str_replace_last( "/images", "/images/$wikiID", $path );
+		$path = str_replace_last( "/canasta_img.php", "/canasta_img.php/$wikiID", $path );
+	} else {
+		error_log( 'Warning: wikiID is not set or empty' );
+	}
+
+	$user = RequestContext::getMain()->getUser();
+
+	// Various extensions may have their own backends that need access.
+	// Check if there is a special backend and storage base path for this file.
+	foreach ( $wgImgAuthUrlPathMap as $prefix => $storageDir ) {
+		$prefix = rtrim( $prefix, '/' ) . '/'; // implicit trailing slash
+		if ( strpos( $path, $prefix ) === 0 ) {
+			$be = $services->getFileBackendGroup()->backendFromPath( $storageDir );
+			$filename = $storageDir . substr( $path, strlen( $prefix ) ); // strip prefix
+			// Check basic user authorization
+			$isAllowedUser = $permissionManager->userHasRight( $user, 'read' );
+			if ( !$isAllowedUser ) {
+				wfForbidden( 'img-auth-accessdenied', 'img-auth-noread', $path );
+				return;
+			}
+			if ( $be->fileExists( [ 'src' => $filename ] ) ) {
+				wfDebugLog( 'canasta_img', "Streaming `" . $filename . "`." );
+				$be->streamFile( [
+					'src' => $filename,
+					'headers' => [ 'Cache-Control: private', 'Vary: Cookie' ]
+				] );
+			} else {
+				wfForbidden( 'img-auth-accessdenied', 'img-auth-nofile', $path );
+			}
+			return;
+		}
+	}
+
+	// Get the local file repository
+	$repo = $services->getRepoGroup()->getRepo( 'local' );
+	$zone = strstr( ltrim( $path, '/' ), '/', true );
+
+	// Get the full file storage path and extract the source file name.
+	// (e.g. 120px-Foo.png => Foo.png or page2-120px-Foo.png => Foo.png).
+	// This only applies to thumbnails/transcoded, and each of them should
+	// be under a folder that has the source file name.
+	if ( $zone === 'thumb' || $zone === 'transcoded' ) {
+		$name = wfBaseName( dirname( $path ) );
+		$filename = $repo->getZonePath( $zone ) . substr( $path, strlen( "/" . $zone ) );
+		// Check to see if the file exists
+		if ( !$repo->fileExists( $filename ) ) {
+			wfForbidden( 'img-auth-accessdenied', 'img-auth-nofile', $filename );
+			return;
+		}
+	} else {
+		$name = wfBaseName( $path ); // file is a source file
+		$filename = $repo->getZonePath( 'public' ) . $path;
+		// Check to see if the file exists and is not deleted
+		$bits = explode( '!', $name, 2 );
+		if ( substr( $path, 0, 9 ) === '/archive/' && count( $bits ) == 2 ) {
+			$file = $repo->newFromArchiveName( $bits[1], $name );
+		} else {
+			$file = $repo->newFile( $name );
+		}
+		if ( !$file->exists() || $file->isDeleted( File::DELETED_FILE ) ) {
+			wfForbidden( 'img-auth-accessdenied', 'img-auth-nofile', $filename );
+			return;
+		}
+	}
+
+	$headers = []; // extra HTTP headers to send
+
+	$title = Title::makeTitleSafe( NS_FILE, $name );
+
+	if ( !$publicWiki ) {
+		// For private wikis, run extra auth checks and set cache control headers
+		$headers['Cache-Control'] = 'private';
+		$headers['Vary'] = 'Cookie';
+
+		if ( !$title instanceof Title ) { // files have valid titles
+			wfForbidden( 'img-auth-accessdenied', 'img-auth-badtitle', $name );
+			return;
+		}
+
+		// Run hook for extension authorization plugins
+		/** @var array $result */
+		$result = null;
+		if ( !Hooks::runner()->onImgAuthBeforeStream( $title, $path, $name, $result ) ) {
+			wfForbidden( $result[0], $result[1], array_slice( $result, 2 ) );
+			return;
+		}
+
+		// Check user authorization for this title
+		// Checks Whitelist too
+
+		if ( !$permissionManager->userCan( 'read', $user, $title ) ) {
+			wfForbidden( 'img-auth-accessdenied', 'img-auth-noread', $name );
+			return;
+		}
+	}
+
+	if ( isset( $_SERVER['HTTP_RANGE'] ) ) {
+		$headers['Range'] = $_SERVER['HTTP_RANGE'];
+	}
+	if ( isset( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) ) {
+		$headers['If-Modified-Since'] = $_SERVER['HTTP_IF_MODIFIED_SINCE'];
+	}
+
+	if ( $request->getCheck( 'download' ) ) {
+		$headers['Content-Disposition'] = 'attachment';
+	}
+
+	// Allow modification of headers before streaming a file
+	Hooks::runner()->onImgAuthModifyHeaders( $title->getTitleValue(), $headers );
+
+	// Stream the requested file
+	list( $headers, $options ) = HTTPFileStreamer::preprocessHeaders( $headers );
+	wfDebugLog( 'canasta_img', "Streaming `" . $filename . "`." );
+	$repo->streamFileWithStatus( $filename, $headers, $options );
+}
+
+/**
+ * Issue a standard HTTP 403 Forbidden header ($msg1-a message index, not a message) and an
+ * error message ($msg2, also a message index), (both required) then end the script
+ * subsequent arguments to $msg2 will be passed as parameters only for replacing in $msg2
+ * @param string $msg1
+ * @param string $msg2
+ * @param mixed ...$args To pass as params to wfMessage() with $msg2. Either variadic, or a single
+ *   array argument.
+ */
+function wfForbidden( $msg1, $msg2, ...$args ) {
+	global $wgImgAuthDetails;
+
+	$args = ( isset( $args[0] ) && is_array( $args[0] ) ) ? $args[0] : $args;
+
+	$msgHdr = wfMessage( $msg1 )->text();
+	$detailMsgKey = $wgImgAuthDetails ? $msg2 : 'badaccess-group0';
+	$detailMsg = wfMessage( $detailMsgKey, $args )->text();
+
+	wfDebugLog( 'canasta_img',
+		"wfForbidden Hdr: " . wfMessage( $msg1 )->inLanguage( 'en' )->text() . " Msg: " .
+			wfMessage( $msg2, $args )->inLanguage( 'en' )->text()
+	);
+
+	HttpStatus::header( 403 );
+	header( 'Cache-Control: no-cache' );
+	header( 'Content-Type: text/html; charset=utf-8' );
+	$templateParser = new TemplateParser();
+	echo $templateParser->processTemplate( 'ImageAuthForbidden', [
+		'msgHdr' => $msgHdr,
+		'detailMsg' => $detailMsg,
+	] );
+}
+
+function str_replace_last( $search, $replace, $subject ) {
+	if ( ( $pos = strrpos( $subject, $search ) ) !== false ) {
+		$subject = substr_replace( $subject, $replace, $pos, strlen( $search ) );
+	}
+	return $subject;
+}

--- a/_sources/canasta/getMediawikiSettings.php
+++ b/_sources/canasta/getMediawikiSettings.php
@@ -4,7 +4,7 @@ use MediaWiki\MediaWikiServices;
 
 $mwHome = getenv( 'MW_HOME' );
 
-if ( !defined( 'MW_CONFIG_FILE' ) && !file_exists( "$mwHome/LocalSettings.php" ) ) {
+if ( !defined( 'MW_CONFIG_FILE' ) && !file_exists( "$mwHome/LocalSettings.php" ) && !file_exists( "$mwHome/CommonSettings.php" ) ) {
 	return;
 }
 

--- a/_sources/configs/.htaccess
+++ b/_sources/configs/.htaccess
@@ -9,8 +9,8 @@ Options -Indexes
 # VisualEditor support
 RewriteRule ^/?w/rest.php/ - [L]
 
-# Image authorization support
-RewriteRule ^/?w/img_auth.php/ - [L]
+# Redirects requests to canasta_img.php for handling image authorization in Canasta.
+RewriteRule ^/?w/canasta_img.php/ - [L]
 
 # Redirect / to Main Page
 RewriteRule ^/*$ %{DOCUMENT_ROOT}/w/index.php [L]

--- a/_sources/scripts/config-subdir-wikis.sh
+++ b/_sources/scripts/config-subdir-wikis.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Parse the YAML file and get wiki paths
+wiki_paths=$(awk -F'/' '/url: .*/ {split($2, arr, "/"); if (arr[length(arr)] != "") print arr[length(arr)]}' $MW_VOLUME/config/wikis.yaml)
+
+# An associative array to keep track of processed paths
+declare -A processed_paths
+
+# Loop through the paths
+for path in $wiki_paths; do
+  if [[ -z ${processed_paths[$path]} ]]; then
+    # Mark this path as processed
+    processed_paths[$path]=1
+
+    # Create directory if it doesn't exist
+    mkdir -p $WWW_ROOT/$path
+
+    # Create symbolic link to MediaWiki
+    ln -sf $MW_HOME $WWW_ROOT/$path
+
+    # Modify .htaccess file
+    sed -e "s|w/rest.php/|$path/w/rest.php/|g" \
+    -e "s|w/canasta_img.php/|$path/w/canasta_img.php/|g" \
+    -e "s|^/*$ %{DOCUMENT_ROOT}/w/index.php|/*$ %{DOCUMENT_ROOT}/$path/w/index.php|" \
+    -e "s|^\\(.*\\)$ %{DOCUMENT_ROOT}/w/index.php|\\1$ %{DOCUMENT_ROOT}/$path/w/index.php|" \
+    $WWW_ROOT/.htaccess > $WWW_ROOT/$path/.htaccess
+
+    # Modify apache2.conf file for canasta_img.php
+    echo "Alias /$path/w/images/ /var/www/mediawiki/w/canasta_img.php/" >> /etc/apache2/apache2.conf
+    echo "Alias /$path/w/images /var/www/mediawiki/w/canasta_img.php" >> /etc/apache2/apache2.conf
+  fi
+done

--- a/_sources/scripts/create-storage-dirs.sh
+++ b/_sources/scripts/create-storage-dirs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Parse the YAML file and get wiki ids
+wiki_ids=$(awk -F': ' '/id: .*/ {print $2}' $MW_VOLUME/config/wikis.yaml)
+
+# Read the ids into an array
+readarray -t ids <<< "$wiki_ids"
+
+# Loop through the ids
+for db_name in "${ids[@]}"; do
+    # Create the cache and images directories if they don't exist
+    mkdir -p $MW_VOLUME/cache/$db_name
+    mkdir -p $MW_VOLUME/images/$db_name
+
+    # Change the permissions of these directories
+    chown -R $WWW_USER:$WWW_GROUP $MW_VOLUME/cache/$db_name
+    chown -R $WWW_USER:$WWW_GROUP $MW_VOLUME/images/$db_name
+done
+
+# Protect Images Directory from Internet Access
+echo "Deny from All" >> $MW_VOLUME/images/.htaccess 

--- a/_sources/scripts/maintenance-scripts/mw_job_runner.sh
+++ b/_sources/scripts/maintenance-scripts/mw_job_runner.sh
@@ -3,12 +3,49 @@
 RJ=$MW_HOME/maintenance/runJobs.php
 
 echo Starting job runner...
+
 # Wait 10 seconds after the server starts up to give other processes time to get started
 sleep 10
-echo Job runner started.
-while true; do
-    # Job types that need to be run ASAP mo matter how many of them are in the queue
-    # Those jobs should be very "cheap" to run
+
+# Check if wikis.yaml file exists
+if [ -f "$MW_VOLUME/config/wikis.yaml" ]; then
+    # Get all wiki ids and URLs from the YAML file using PHP
+    wikis=$(php -r '$wikis = yaml_parse_file("'$MW_VOLUME/config/wikis.yaml'")["wikis"]; foreach ($wikis as $wiki) { echo $wiki["id"] . "," . $wiki["url"] . " "; }')
+
+    for wiki_data in $wikis; do
+        # Split the id and url data into separate variables
+        IFS=',' read -r wiki_id wiki_url <<< "$wiki_data"
+        
+        echo "$wiki_id job runner started"
+
+        {
+            while true; do
+                # Job types that need to be run ASAP no matter how many of them are in the queue
+                # Those jobs should be very "cheap" to run
+                php $RJ --type="enotifNotify" --server="https://$wiki_url" --wiki="$wiki_id" 
+                sleep 1
+                php $RJ --type="createPage" --server="https://$wiki_url" --wiki="$wiki_id" 
+                sleep 1
+                php $RJ --type="refreshLinks" --server="https://$wiki_url" --wiki="$wiki_id" 
+                sleep 1
+                php $RJ --type="htmlCacheUpdate" --maxjobs=500 --server="https://$wiki_url" --wiki="$wiki_id" 
+                sleep 1
+                # Everything else, limit the number of jobs on each batch
+                # The --wait parameter will pause the execution here until new jobs are added,
+                # to avoid running the loop without anything to do
+                php $RJ --maxjobs=10 --server="https://$wiki_url" --wiki="$wiki_id" 
+
+                # Wait some seconds to let the CPU do other things, like handling web requests, etc
+                echo mwjobrunner waits for "$MW_JOB_RUNNER_PAUSE" seconds...
+                sleep "$MW_JOB_RUNNER_PAUSE"
+            done
+        } &
+    done
+else
+    # wikis.yaml file does not exist. Skip parsing and running specific wiki jobs.
+    echo "Warning: wikis.yaml does not exist. Running general jobs."
+    
+    # Place your general (non-wiki-specific) job run commands here.
     php $RJ --type="enotifNotify"
     sleep 1
     php $RJ --type="createPage"
@@ -17,12 +54,8 @@ while true; do
     sleep 1
     php $RJ --type="htmlCacheUpdate" --maxjobs=500
     sleep 1
-    # Everything else, limit the number of jobs on each batch
-    # The --wait parameter will pause the execution here until new jobs are added,
-    # to avoid running the loop without anything to do
     php $RJ --maxjobs=10
+fi
 
-    # Wait some seconds to let the CPU do other things, like handling web requests, etc
-    echo mwjobrunner waits for "$MW_JOB_RUNNER_PAUSE" seconds...
-    sleep "$MW_JOB_RUNNER_PAUSE"
-done
+# Wait for all background jobs to finish
+wait

--- a/_sources/scripts/maintenance-scripts/mw_transcoder.sh
+++ b/_sources/scripts/maintenance-scripts/mw_transcoder.sh
@@ -1,16 +1,44 @@
 #!/bin/bash
 
 RJ=$MW_HOME/maintenance/runJobs.php
+
 echo Starting transcoder...
+
 # Wait three minutes after the server starts up to give other processes time to get started
 sleep 180
-echo Transcoder started.
-while true; do
-    php $RJ --type webVideoTranscodePrioritized --maxjobs=10
-    sleep 1
-    php $RJ --type webVideoTranscode --maxjobs=1
 
+# Get all wiki ids and URLs from the YAML file using PHP
+if [ -f "$MW_VOLUME/config/wikis.yaml" ]; then
+    # Get all wiki ids and URLs from the YAML file using PHP
+    wikis=$(php -r 'foreach (yaml_parse_file("'$MW_VOLUME/config/wikis.yaml'")["wikis"] as $wiki) echo $wiki["id"] . "," . $wiki["url"] . " ";')
+
+    for wiki in $wikis; do
+        # Extract wiki id and url
+        IFS=', ' read -r -a wiki_data <<< "$wiki"
+        wiki_id=${wiki_data[0]}
+        wiki_url=${wiki_data[1]}
+        echo "$wiki_id transcoder started."
+        {
+            while true; do
+                php $RJ --type=webVideoTranscodePrioritized --maxjobs=10 --wiki="$wiki_id" --server="https://$wiki_url"
+                sleep 1
+                php $RJ --type=webVideoTranscode --maxjobs=1 --wiki="$wiki_id" --server="https://$wiki_url"
+
+                # Wait some seconds to let the CPU do other things, like handling web requests, etc
+                echo mwtranscoder waits for "$MW_JOB_TRANSCODER_PAUSE" seconds...
+                sleep "$MW_JOB_TRANSCODER_PAUSE"
+            done
+        } &
+    done
+else
+    echo "Warning: wikis.yaml does not exist. Starting the general transcoder."
+    php $RJ --type=webVideoTranscodePrioritized --maxjobs=10
+    sleep 1
+    php $RJ --type=webVideoTranscode --maxjobs=1
     # Wait some seconds to let the CPU do other things, like handling web requests, etc
     echo mwtranscoder waits for "$MW_JOB_TRANSCODER_PAUSE" seconds...
     sleep "$MW_JOB_TRANSCODER_PAUSE"
-done
+fi
+
+# Wait for all background jobs to finish
+wait

--- a/_sources/scripts/run-apache.sh
+++ b/_sources/scripts/run-apache.sh
@@ -147,6 +147,18 @@ run_autoupdate () {
     echo "Auto-update completed"
 }
 
+config_subdir_wikis() {
+    echo "Configuring subdirectory wikis..."
+    /config-subdir-wikis.sh
+    echo "Configured subdirectory wikis..."
+}
+
+create_storage_dirs() {
+    echo "Creating cache and images dirs..."
+    /create-storage-dirs.sh
+    echo "Created cache and images dirs..."
+}
+
 check_mount_points () {
   # Check for $MW_HOME/user-extensions presence and bow out if it's not in place
   if [ ! -d "$MW_HOME/user-extensions" ]; then
@@ -176,14 +188,19 @@ cd "$MW_HOME" || exit
 
 ########## Run maintenance scripts ##########
 echo "Checking for LocalSettings..."
-if [ -e "$MW_VOLUME/config/LocalSettings.php"  ]; then
+if [ -e "$MW_VOLUME/config/LocalSettings.php" ] || [ -e "$MW_VOLUME/config/CommonSettings.php" ]; then
   # Run auto-update
   run_autoupdate
+  if [ -e "$MW_VOLUME/config/wikis.yaml" ]; then
+    config_subdir_wikis
+    create_storage_dirs
+  fi
 fi
 
 echo "Starting services..."
 
 run_maintenance_scripts &
+inotifywait &
 
 # Running php-fpm
 /run-php-fpm.sh &


### PR DESCRIPTION
# AddWiki Farm Support in Canasta

Related Issue: #57 
### Overview
One big feature Canasta lacks is the ability to support running multiple wikis, i.e. a wiki family or wiki farm, within the same container. Such wikis would be differentiated by either:

a different directory (e.g. example.com/a, example.com/b)
a different subdomain (e.g. a.example.com, b.example.com)
or different domains for each wiki (example1.com, example2.com).

We added wiki farm support for canasta.

### New Features and Improvements
- **Wiki Farm Support**: The updated implementation allows multiple wikis to run independently within a single container.
- **Enhanced CLI**: Canasta's command-line interface is now extended to manage wiki farm configurations effortlessly.

### Implementation Details
1. **Common Setting**: A shared configuration file provides settings that are common across all wikis.
2. **Unique IDs and settings**: Each wiki has a unique ID that allows for customized settings.
3. **Auto-Generated `.htaccess`**: The `generatewikihtaccess.sh` script automatically sets up `.htaccess` files for wikis hosted under directories, thereby managing access permissions.

### Test
We deployed the Canasta2.0 on the AWS.
Now it have three wikis running in one container.
[https://canasta2.com](https://canasta2.com)
[https://canasta2.com/a](https://canasta2.com/a)
[https://subdomain.canasta2.com](https://subdomain.canasta2.com)
They are all publicly accessible and everyone is welcome to test them.