### PR TITLE
Update version of WhosOnline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -588,9 +588,9 @@ RUN set -x; \
 	&& cd $MW_HOME/extensions/WhoIsWatching \
 	&& git checkout -q 836a31018e26ab7c993088c4cca31a89efec2ee5 \
 	# WhosOnline
-	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-WhosOnline $MW_HOME/extensions/WhosOnline \
+	&& git clone --single-branch -b master https://github.com/wikimedia/mediawiki-extensions-WhosOnline $MW_HOME/extensions/WhosOnline \
 	&& cd $MW_HOME/extensions/WhosOnline \
-	&& git checkout -q bb1765d2eb5c88ca10dc8a0be19f35fcffdccdae \
+	&& git checkout -q d3d63faa08b89c429a7803b283e9bb685a51b9a0 \
 	# Widgets
 	&& git clone --single-branch -b $MW_VERSION https://github.com/wikimedia/mediawiki-extensions-Widgets $MW_HOME/extensions/Widgets \
 	&& cd $MW_HOME/extensions/Widgets \


### PR DESCRIPTION
The REL1_39 version has broken SQL, the fix for which (T328852) was only added to the master branch at the time. While it is available on the REL1_40 branch now, I believe it is preferable to use the master branch rather than a release-specific branch that is different from the targeted release (1.39).

Clone the (current) latest version of the master branch to include subsequent localization updates and other improvements since we are upgrading anyway.