### PR TITLE
Adding templates for GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a bug report
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+**Summary**: A clear, one-sentence summary of what the bug is.
+
+**Description**: Full description of what happens.
+
+**Screenshots**: If applicable, add screenshots to help explain your problem.
+
+**Steps to reproduce the behavior**:
+1. Run `canasta ,,,`
+2. Add `foo.php` into `config/bar.php`
+3. Open wiki to `Main Page`
+4. Error appears
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## System info
+_Please complete the following information:_
+ - MediaWiki version (e.g. 1.39.7)
+ - Canasta version
+ - Installed extensions and versions (e.g. Semantic MediaWiki 4.0.2, Cargo as of 2024-04-20, etc.)
+ - Any other context you think is appropriate to include here

--- a/.github/ISSUE_TEMPLATE/extension_request.md
+++ b/.github/ISSUE_TEMPLATE/extension_request.md
@@ -1,0 +1,33 @@
+---
+name: Extension or skin request
+about: Propose to add or remove an extension or skin for Canasta
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+### Name of extension
+
+### MediaWiki.org page (if it exists)
+https://www.mediawiki.org/wiki/Extension:
+
+### Link to the repo
+_GitHub preferred, Gerrit is fine too._
+
+### Justification
+_Explain in a few sentences why this extension or skin should be bundled._
+
+### How often is this extension/skin updated?
+_e.g. Every few months_
+
+### How many people contribute to this extension regularly?
+How many consistent maintainers are there (i.e. those who would be capable of continuing the extension's development in the other maintainers' absence)? Do not include people who make one-time or occasional contributions.
+
+### Are you the author of this extension/skin?
+Yes/No
+
+### Have you checked that this extension or skin isn't already bundled in Canasta?
+Yes/No
+
+### (Extensions only) Have you checked there are no similar extensions to it already bundled in Canasta?
+Yes/No

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Propose an idea for Canasta (does not include requests to add/update/remove bundled extensions or skins)
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## The current situation
+A clear and concise description of what the current situation is.
+
+## The proposed result
+A clear and concise description of what you want to happen.
+
+## Alternatives (if any)
+Not always applicable, but if there are any alternative solutions Canasta could explore, please add them here.

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,0 +1,42 @@
+---
+name: Community support request
+about: Get support from the community for when you are unsure if it is a bug.
+title: ''
+labels: question
+assignees: ''
+---
+
+## Describe the situation
+**Summary**: A clear, one-sentence summary of what your situation is. _e.g. Varnish guru meditation error continues to appear after 5 minutes of starting up Canasta._
+
+**Description**: Full description of the situation.
+
+**Screenshots**: If applicable, add screenshots to help elucidate your situation.
+
+**Steps to reproduce the issue** (if applicable):
+1. Run `canasta ,,,`
+2. Add `foo.php` into `config/bar.php`
+3. Open wiki to `Main Page`
+4. Error appears
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## System info
+_Please complete the following information:_
+ - MediaWiki version (e.g. 1.39.7)
+ - Canasta version
+ - Canasta CLI version
+ - Installed extensions and versions (e.g. Semantic MediaWiki 4.0.2, Cargo as of 2024-04-20, etc.)
+ - Host operating system
+ - Do you have sudo/root permissions on the host OS?
+ - Any other context you think is appropriate to include here
+
+## Sanity checks
+Only applies to troubleshooting requests.
+
+- Have you checked the documentation on canasta.wiki for how to address this? Yes/No
+- Have you checked prior issues on GitHub yet? Yes/No
+- Are you following all Canasta approaches and have **_avoided_** doing things such as running `docker exec` directly on the container, removing the Caddy/Varnish containers, adding unauthorized files to the Docker container after startup, etc.? Yes/No
+
+If you answered no to any of the above sanity check questions, please do not open this support request until you can answer yes to all of the questions.


### PR DESCRIPTION
This will help us classify issues a lot better. Additionally, we can get more information from each issue creator sooner rather than later.