### PR TITLE
Change extension-setup.sh from /bin/sh to /bin/bash

### DIFF
--- a/_sources/scripts/extension-setup.sh
+++ b/_sources/scripts/extension-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 MW_HOME="$MW_HOME"
 MW_VERSION="$MW_VERSION"


### PR DESCRIPTION
Needed in order to pass GitHub's validation - before this change, GitHub claimed that the script couldn't find the file extensions.yaml, though they're in the same (/tmp/) directory.