### PR TITLE
Update to CanastaBase 1.3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/canastawiki/canasta-base:1.3.19
+ARG BASE_IMAGE=ghcr.io/canastawiki/canasta-base:1.3.20
 FROM ${BASE_IMAGE} AS base
 
 LABEL maintainers=""


### PR DESCRIPTION
Bumps the base image pin to CanastaBase 1.3.20.

The image carries no apt steps of its own, so its OS packages come entirely from the base. This clears
the fixable `php8.2` (CVE-2026-17543), `libaprutil1` (CVE-2026-34191) and `python3-httplib2`
(CVE-2026-59939) findings reported against the published images in #692.

CVE-2026-69246 in `guzzlehttp/guzzle` is not cleared — MediaWiki 1.43.9 pins `7.12.3` exactly, and the
bump to `7.15.2` landed on `REL1_43` after the tag was cut, so it resolves when 1.43.10 ships.

1.3.20 also brings server-side logo resolution for the wiki directory on private farms.

Closes #695.

Refs #692
